### PR TITLE
JDK-8212060: Prevent windows from visibly changing position

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1254,7 +1254,20 @@ void WindowContextTop::window_configure(XWindowChanges *windowChanges,
         if (windowChangesMask & CWY) {
             newY = windowChanges->y;
         }
+
+        //JDK-8212060: as gtk docs states, some window managers will only move the
+        //window after its shown. This prevents the glitch.
+        bool hide_and_show = is_visible();
+
+        if (hide_and_show) {
+            gtk_widget_hide(gtk_widget);
+        }
+
         gtk_window_move(GTK_WINDOW(gtk_widget), newX, newY);
+
+        if (hide_and_show) {
+            gtk_widget_show_all(gtk_widget);
+        }
     }
 
     if (windowChangesMask & (CWWidth | CWHeight)) {


### PR DESCRIPTION
As gtk docs states:

"Asks the window manager to move window to the given position. Window managers are free to ignore this; most window managers ignore requests for initial window positions (instead using a user-defined placement algorithm) and honor requests after the window has already been shown."

This creates a visible glitch - so this fix hides the window before moving it.